### PR TITLE
Add Persistence relayer and channels they are looking to be supported

### DIFF
--- a/roles/hermes/templates/fragments/comdex.toml.j2
+++ b/roles/hermes/templates/fragments/comdex.toml.j2
@@ -22,4 +22,5 @@ list = [
   ['transfer', 'channel-1'], # Osmosis
   ['transfer', 'channel-18'], # Juno
   ['transfer', 'channel-65'], # Secret
+  ['transfer', 'channel-57'], # persistence
 ]

--- a/roles/hermes/templates/fragments/injective.toml.j2
+++ b/roles/hermes/templates/fragments/injective.toml.j2
@@ -29,6 +29,7 @@ list = [
   ['transfer', 'channel-88'], # Secret
   ['transfer', 'channel-89'], # Stride
   ['transfer', 'channel-102'], # White Whale 
-  ['transfer', 'channel-104'], # Terra2 
+  ['transfer', 'channel-104'], # Terra2
+  ['transfer', 'channel-82'], # persistence
   ['wasm.inj1rsrefjc7xnl6d6fm6avl706nu5y6nkpxffyevq', 'channel-105'], # Terra2 
 ]

--- a/roles/hermes/templates/fragments/kujira.toml.j2
+++ b/roles/hermes/templates/fragments/kujira.toml.j2
@@ -31,4 +31,5 @@ list = [
   ['transfer', 'channel-32'], # Stride
   ['transfer', 'channel-44'], # Stride
   ['transfer', 'channel-55'], # Mars
+  ['transfer', 'channel-56'], # persistence
 ]

--- a/roles/hermes/templates/fragments/persistence.toml.j2
+++ b/roles/hermes/templates/fragments/persistence.toml.j2
@@ -1,0 +1,33 @@
+[[chains]]
+id = 'core-1'
+{% include 'ports.toml.j2' %}
+
+rpc_timeout = '10s'
+account_prefix = 'persistence'
+key_name = 'relayer'
+store_prefix = 'ibc'
+default_gas = 100000
+max_gas = 1000000
+gas_price = { price = 0.025, denom = 'uxprt' }
+#gas_adjustment = 0.1
+gas_multiplier = 1.2
+max_msg_num = 30
+max_tx_size = 2000000
+clock_drift = '5s'
+max_block_time = '10s'
+trusting_period = '14days'
+trust_threshold = { numerator = '1', denominator = '3' }
+address_type = { derivation = 'cosmos' }
+
+memo_prefix = '{{ memo }}'
+
+[chains.packet_filter]
+policy = 'allow'
+list = [
+  ['transfer', 'channel-82'], # secret
+  ['transfer', 'channel-67'], # Stride
+  ['transfer', 'channel-41'], # Injective
+  ['transfer', 'channel-72'], # Kujira
+  ['transfer', 'channel-71'], # comdex
+  ['transfer', 'channel-73'], # quicksilver
+]

--- a/roles/hermes/templates/fragments/quicksilver.toml.j2
+++ b/roles/hermes/templates/fragments/quicksilver.toml.j2
@@ -22,5 +22,6 @@ memo_prefix = '{{ memo }}'
 [chains.packet_filter]
 policy = 'allow'
 list = [
-  ['transfer', 'channel-7'],
+  ['transfer', 'channel-7'], #evmos
+  ['transfer', 'channel-16'], # persistence
 ]

--- a/roles/hermes/templates/fragments/secretnetwork.toml.j2
+++ b/roles/hermes/templates/fragments/secretnetwork.toml.j2
@@ -38,6 +38,7 @@ list = [
   ['transfer', 'channel-51'], # Agoric
   ['transfer', 'channel-57'], # Whitewhale
   ['transfer', 'channel-62'], # Jackal
+  ['transfer', 'channel-64'], # Persistence
   ['wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4', 'channel-44'], # Osmosis SNIP20
   ['wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4', 'channel-45'], # Juno SNIP20
   ['wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4', 'channel-46'], # Kujira SNIP20

--- a/roles/hermes/templates/fragments/stride.toml.j2
+++ b/roles/hermes/templates/fragments/stride.toml.j2
@@ -55,4 +55,5 @@ list = [
   ['transfer', 'channel-6'], # Injective
   ['transfer', 'channel-8'], # Kujira
   ['transfer', 'channel-40'], # Secret
+  ['transfer', 'channel-53'], # persistence
 ]


### PR DESCRIPTION
https://docs.persistence.one/build/relayers/ibc-channels

@dylanschultzie can you alter the ansible so that we can use the following endpoints:

grpc.core.persistence.one:443
and
wss://rpc.core.persistence.one:443/websocket